### PR TITLE
Bump `geo` form 0.23.1 to 0.25.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bevy-earcutr = "0.9"
 bevy = { version = "0.10", default-features = false,  features = ["bevy_render"] }
-geo = "0.23"
+geo = "0.25"


### PR DESCRIPTION
0.25 fixes https://github.com/georust/geo/issues/1013. A necessity for setting up [the recommended bevy performance optimizations](https://bevyengine.org/learn/book/getting-started/setup/#compile-with-performance-optimizations).