### PR TITLE
Empowered color handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo-bevy"
 description = "Generate Bevy meshes from `geo` types"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 edition = "2021"
 repository = "https://github.com/frewsxcv/geo-bevy"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,27 +18,6 @@ pub enum PreparedMesh {
     },
 }
 
-type Vertex = [f32; 3]; // [x, y, z]
-
-fn build_mesh_from_vertices(
-    primitive_topology: bevy::render::render_resource::PrimitiveTopology,
-    vertices: Vec<Vertex>,
-    indices: Vec<u32>,
-) -> Mesh {
-    let num_vertices = vertices.len();
-    let mut mesh = Mesh::new(primitive_topology);
-    mesh.set_indices(Some(bevy::render::mesh::Indices::U32(indices)));
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
-
-    let normals = vec![[0.0, 0.0, 0.0]; num_vertices];
-    let uvs = vec![[0.0, 0.0]; num_vertices];
-
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
-
-    mesh
-}
-
 trait BuildMesh {
     fn build(self) -> Option<PreparedMesh>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-use std::num::TryFromIntError;
 use bevy::prelude::*;
 use geo::algorithm::coords_iter::CoordsIter;
+use std::num::TryFromIntError;
 
 mod line_string;
 mod point;
 
 pub enum PreparedMesh {
     Point(Vec<geo::Point>),
-    LineString { mesh: Mesh, color: Color },
-    Polygon { mesh: Mesh, color: Color },
+    LineString { mesh: Mesh },
+    Polygon { mesh: Mesh },
 }
 
 type Vertex = [f32; 3]; // [x, y, z]
@@ -42,7 +42,6 @@ pub struct BuildBevyMeshesContext {
 
 pub fn build_bevy_meshes<G: BuildBevyMeshes>(
     geo: &G,
-    color: Color,
 ) -> Result<impl Iterator<Item = PreparedMesh>, TryFromIntError> {
     let mut ctx = BuildBevyMeshesContext::default();
 
@@ -51,11 +50,11 @@ pub fn build_bevy_meshes<G: BuildBevyMeshes>(
     info_span!("Building Bevy meshes").in_scope(|| {
         Ok([
             ctx.point_mesh_builder.build(),
-            ctx.line_string_mesh_builder.build(color),
+            ctx.line_string_mesh_builder.build(),
             ctx.polygon_mesh_builder
                 .build()
-                .map(|mesh| PreparedMesh::Polygon { mesh, color }),
-            ctx.polygon_border_mesh_builder.build(Color::BLACK),
+                .map(|mesh| PreparedMesh::Polygon { mesh }),
+            ctx.polygon_border_mesh_builder.build(),
         ]
         .into_iter()
         .flatten())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use geo::algorithm::coords_iter::CoordsIter;
 use std::num::TryFromIntError;
 
 mod line_string;
@@ -174,31 +173,5 @@ impl BuildBevyMeshes for geo::GeometryCollection {
             g.populate_mesh_builders(ctx)?;
         }
         Ok(())
-    }
-}
-
-fn polygon_to_earcutr_input(polygon: &geo::Polygon) -> bevy_earcutr::EarcutrInput {
-    let mut vertices = Vec::with_capacity(polygon.coords_count() * 2);
-    let mut interior_indices = Vec::with_capacity(polygon.interiors().len());
-    debug_assert!(polygon.exterior().0.len() >= 4);
-
-    flat_line_string_coords_2(polygon.exterior(), &mut vertices);
-
-    for interior in polygon.interiors() {
-        debug_assert!(interior.0.len() >= 4);
-        interior_indices.push(vertices.len() / 2);
-        flat_line_string_coords_2(interior, &mut vertices);
-    }
-
-    bevy_earcutr::EarcutrInput {
-        vertices,
-        interior_indices,
-    }
-}
-
-fn flat_line_string_coords_2(line_string: &geo::LineString, vertices: &mut Vec<f64>) {
-    for coord in &line_string.0 {
-        vertices.push(coord.x);
-        vertices.push(coord.y);
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -1,5 +1,4 @@
 use crate::Vertex;
-use bevy::prelude::Color;
 use std::num;
 
 #[derive(Default)]
@@ -29,7 +28,7 @@ impl LineStringMeshBuilder {
         Ok(())
     }
 
-    pub fn build(self, color: Color) -> Option<crate::PreparedMesh> {
+    pub fn build(self) -> Option<crate::PreparedMesh> {
         if self.vertices.is_empty() {
             None
         } else {
@@ -39,7 +38,6 @@ impl LineStringMeshBuilder {
                     self.vertices,
                     self.indices,
                 ),
-                color,
             })
         }
     }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -27,18 +27,24 @@ impl LineStringMeshBuilder {
         }
         Ok(())
     }
+}
 
-    pub fn build(self) -> Option<crate::PreparedMesh> {
+impl From<LineStringMeshBuilder> for bevy::prelude::Mesh {
+    fn from(line_string_builder: LineStringMeshBuilder) -> Self {
+        crate::build_mesh_from_vertices(
+            bevy::render::render_resource::PrimitiveTopology::LineList,
+            line_string_builder.vertices,
+            line_string_builder.indices,
+        )
+    }
+}
+
+impl crate::BuildMesh for LineStringMeshBuilder {
+    fn build(self) -> Option<crate::PreparedMesh> {
         if self.vertices.is_empty() {
             None
         } else {
-            Some(crate::PreparedMesh::LineString {
-                mesh: crate::build_mesh_from_vertices(
-                    bevy::render::render_resource::PrimitiveTopology::LineList,
-                    self.vertices,
-                    self.indices,
-                ),
-            })
+            Some(crate::PreparedMesh::LineString { mesh: self.into() })
         }
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -1,5 +1,7 @@
-use crate::Vertex;
+use bevy::prelude::Mesh;
 use std::num;
+
+type Vertex = [f32; 3]; // [x, y, z]
 
 #[derive(Default)]
 pub struct LineStringMeshBuilder {
@@ -29,13 +31,22 @@ impl LineStringMeshBuilder {
     }
 }
 
-impl From<LineStringMeshBuilder> for bevy::prelude::Mesh {
+impl From<LineStringMeshBuilder> for Mesh {
     fn from(line_string_builder: LineStringMeshBuilder) -> Self {
-        crate::build_mesh_from_vertices(
-            bevy::render::render_resource::PrimitiveTopology::LineList,
-            line_string_builder.vertices,
-            line_string_builder.indices,
-        )
+        let vertices = line_string_builder.vertices;
+        let indices = line_string_builder.indices;
+        let num_vertices = vertices.len();
+        let mut mesh = Mesh::new(bevy::render::render_resource::PrimitiveTopology::LineList);
+        mesh.set_indices(Some(bevy::render::mesh::Indices::U32(indices)));
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+
+        let normals = vec![[0.0, 0.0, 0.0]; num_vertices];
+        let uvs = vec![[0.0, 0.0]; num_vertices];
+
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+
+        mesh
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -11,8 +11,10 @@ impl PointMeshBuilder {
         self.points.push(*point);
         Ok(())
     }
+}
 
-    pub fn build(self) -> Option<crate::PreparedMesh> {
+impl crate::BuildMesh for PointMeshBuilder {
+    fn build(self) -> Option<crate::PreparedMesh> {
         if self.points.is_empty() {
             None
         } else {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,0 +1,42 @@
+use crate::{line_string::LineStringMeshBuilder, PreparedMesh};
+
+#[derive(Default)]
+pub struct PolygonMeshBuilder {
+    polygon: bevy_earcutr::PolygonMeshBuilder,
+    exterior: LineStringMeshBuilder,
+    interiors: Vec<LineStringMeshBuilder>,
+}
+
+impl PolygonMeshBuilder {
+    pub fn add_polygon_components(
+        &mut self,
+        polygon: &geo::Polygon,
+    ) -> Result<(), std::num::TryFromIntError> {
+        self.polygon
+            .add_earcutr_input(crate::polygon_to_earcutr_input(polygon));
+        self.exterior.add_line_string(polygon.exterior())?;
+        for interior in polygon.interiors() {
+            let mut interior_line_string_builder = LineStringMeshBuilder::default();
+            interior_line_string_builder.add_line_string(interior)?;
+            self.interiors.push(interior_line_string_builder);
+        }
+
+        Ok(())
+    }
+}
+
+impl crate::BuildMesh for PolygonMeshBuilder {
+    fn build(self) -> Option<PreparedMesh> {
+        self.polygon
+            .build()
+            .map(|polygon_mesh| PreparedMesh::Polygon {
+                polygon_mesh,
+                exterior_mesh: self.exterior.into(),
+                interior_meshes: self
+                    .interiors
+                    .into_iter()
+                    .map(|interior_builder| interior_builder.into())
+                    .collect(),
+            })
+    }
+}


### PR DESCRIPTION
Passing a color through `build_bevy_meshes(color)` limits the possibility to use separate colors for the different variants of `PreparedMesh`. The workaround is to simply provide one separately when spawning the respective entities:

```rust
    // Passing a color serves little use here:
    for prepared_mesh in build_bevy_meshes(&geometry, Color::WHITE).unwrap() {
        match prepared_mesh {
            PreparedMesh::LineString { mesh, color } => {
                commands.spawn(MaterialMeshBundle {
                    mesh: meshes.add(mesh),
                    material: gen_random_color_material(materials),
                    ..default()
                });
            }
            PreparedMesh::Polygon { mesh, color } => {
                commands.spawn(MaterialMeshBundle {
                    mesh: meshes.add(mesh),
                    material: gen_random_color_material(materials),
                    ..default()
                });
            }
        }
    }
```

Color is also internally just being passed along, so why pass it through in the first place? 
The first commit of this PR remove the color parameter from `build_bevy_meshes()`, and in turn; any mention of it in the crate.

Another color handling limitation of this crate was how it gave all the polygon borders (exterior and interior line strings) the default `Color::BLACK()`, and then returned them with `PreparedMesh::Linestring(mesh)`. This makes it rather awkward to specify the color by oneself, and practically impossible to differentiate between exterior and interior line strings. The second commit of this PR tries to make this easier by changing the `PreparedMesh::Polygon` variant into a:

```rust
pub enum PreparedMesh {
    // ...
    Polygon {
        polygon_mesh: Mesh,
        exterior_mesh: Mesh,
        interior_meshes: Vec<Mesh>,
    },
}
```

The remaining commits are just some minor cleanups + a version bump as this color handling introduces braking API changes 😊