### PR TITLE
Prepare a mesh for a given geometry.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo-bevy"
 description = "Generate Bevy meshes from `geo` types"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 edition = "2021"
 repository = "https://github.com/frewsxcv/geo-bevy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,3 @@ bevy-earcutr = "0.9"
 bevy = { version = "0.10", default-features = false,  features = ["bevy_render"] }
 geo = "0.25"
 geo-types = "0.7"
-
-[patch.crates-io]
-# TEMP: https://github.com/georust/geo/pull/1020 is yet to included in a release.
-geo-types = { git = "https://github.com/georust/geo" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ license = "MIT OR Apache-2.0"
 bevy-earcutr = "0.9"
 bevy = { version = "0.10", default-features = false,  features = ["bevy_render"] }
 geo = "0.25"
+geo-types = "0.7"
+
+[patch.crates-io]
+# TEMP: https://github.com/georust/geo/pull/1020 is yet to included in a release.
+geo-types = { git = "https://github.com/georust/geo" }

--- a/src/build_mesh.rs
+++ b/src/build_mesh.rs
@@ -1,0 +1,143 @@
+use geo_types::*;
+use std::num::TryFromIntError;
+
+pub trait BuildMesh {
+    fn build(self) -> Option<crate::GeometryMesh>;
+}
+
+#[derive(Default)]
+pub struct BuildBevyMeshesContext {
+    pub point_mesh_builder: crate::point::PointMeshBuilder,
+    pub line_string_mesh_builder: crate::line_string::LineStringMeshBuilder,
+    pub polygon_mesh_builder: crate::polygon::PolygonMeshBuilder,
+}
+
+pub trait BuildBevyMeshes {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError>;
+}
+
+impl BuildBevyMeshes for Point {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        ctx.point_mesh_builder.add_point(self)
+    }
+}
+
+impl BuildBevyMeshes for LineString {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        ctx.line_string_mesh_builder.add_line_string(self)
+    }
+}
+
+impl BuildBevyMeshes for Polygon {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        ctx.polygon_mesh_builder.add_polygon(self)
+    }
+}
+
+impl BuildBevyMeshes for MultiPoint {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for point in &self.0 {
+            point.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for MultiLineString {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for line_string in &self.0 {
+            line_string.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for MultiPolygon {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for polygon in &self.0 {
+            polygon.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for Line {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        LineString::from(self).populate_mesh_builders(ctx)
+    }
+}
+
+impl BuildBevyMeshes for Triangle {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        self.to_polygon().populate_mesh_builders(ctx)
+    }
+}
+
+impl BuildBevyMeshes for Rect {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        self.to_polygon().populate_mesh_builders(ctx)
+    }
+}
+
+impl BuildBevyMeshes for Geometry {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        match self {
+            Geometry::Point(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Line(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::LineString(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Polygon(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::MultiPoint(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::MultiLineString(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::MultiPolygon(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::GeometryCollection(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Triangle(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Rect(g) => g.populate_mesh_builders(ctx)?,
+        };
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for GeometryCollection {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for g in self {
+            g.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,6 @@ pub fn geometry_collection_to_mesh(
 
 pub enum GeometryMesh {
     Point(Vec<Point>),
-    LineString { mesh: Mesh },
+    LineString(Mesh),
     Polygon(polygon::PolygonMesh),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,27 +18,6 @@ pub enum PreparedMesh {
     },
 }
 
-type Vertex = [f32; 3]; // [x, y, z]
-
-fn build_mesh_from_vertices(
-    primitive_topology: bevy::render::render_resource::PrimitiveTopology,
-    vertices: Vec<Vertex>,
-    indices: Vec<u32>,
-) -> Mesh {
-    let num_vertices = vertices.len();
-    let mut mesh = Mesh::new(primitive_topology);
-    mesh.set_indices(Some(bevy::render::mesh::Indices::U32(indices)));
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
-
-    let normals = vec![[0.0, 0.0, 0.0]; num_vertices];
-    let uvs = vec![[0.0, 0.0]; num_vertices];
-
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
-
-    mesh
-}
-
 trait BuildMesh {
     fn build(self) -> Option<PreparedMesh>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-use std::num::TryFromIntError;
 use bevy::prelude::*;
 use geo::algorithm::coords_iter::CoordsIter;
+use std::num::TryFromIntError;
 
 mod line_string;
 mod point;
 
 pub enum PreparedMesh {
     Point(Vec<geo::Point>),
-    LineString { mesh: Mesh, color: Color },
-    Polygon { mesh: Mesh, color: Color },
+    LineString { mesh: Mesh },
+    Polygon { mesh: Mesh },
 }
 
 type Vertex = [f32; 3]; // [x, y, z]
@@ -42,7 +42,6 @@ pub struct BuildBevyMeshesContext {
 
 pub fn build_bevy_meshes<G: BuildBevyMeshes>(
     geo: &G,
-    color: Color,
 ) -> Result<impl Iterator<Item = PreparedMesh>, TryFromIntError> {
     let mut ctx = BuildBevyMeshesContext::default();
 
@@ -51,11 +50,11 @@ pub fn build_bevy_meshes<G: BuildBevyMeshes>(
     info_span!("Building Bevy meshes").in_scope(|| {
         Ok([
             ctx.point_mesh_builder.build(),
-            ctx.line_string_mesh_builder.build(color),
+            ctx.line_string_mesh_builder.build(),
             ctx.polygon_mesh_builder
                 .build()
-                .map(|mesh| PreparedMesh::Polygon { mesh, color }),
-            ctx.polygon_border_mesh_builder.build(Color::BLACK),
+                .map(|mesh| PreparedMesh::Polygon { mesh }),
+            ctx.polygon_border_mesh_builder.build(),
         ]
         .into_iter()
         .flatten())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 use bevy::prelude::{info_span, Mesh};
-use build_mesh::BuildBevyMeshes;
-use build_mesh::BuildMesh;
+use build_mesh::{BuildBevyMeshes, BuildMesh};
 use geo_types::geometry::*;
 use line_string::LineStringMeshBuilder;
-use polygon::PolygonMesh;
 use polygon::PolygonMeshBuilder;
 use std::num::TryFromIntError;
+
+pub use polygon::PolygonMesh;
 
 mod build_mesh;
 mod line_string;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn triangle_to_mesh(triangle: &Triangle) -> Result<Option<PolygonMesh>, TryF
     polygon_to_mesh(&triangle.to_polygon())
 }
 
-pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<PreparedMesh>, TryFromIntError> {
+pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<GeometryMesh>, TryFromIntError> {
     let mut ctx = BuildBevyMeshesContext::default();
 
     info_span!("Populating Bevy mesh builder")
@@ -82,7 +82,7 @@ pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<PreparedMesh>, Try
 
 pub fn geometry_collection_to_mesh(
     geometry_collection: &GeometryCollection,
-) -> Result<Vec<PreparedMesh>, TryFromIntError> {
+) -> Result<Vec<GeometryMesh>, TryFromIntError> {
     let mut geometry_meshes = Vec::with_capacity(geometry_collection.len());
     for geometry in geometry_collection {
         if let Some(geometry_mesh) = geometry_to_mesh(geometry)? {
@@ -93,14 +93,14 @@ pub fn geometry_collection_to_mesh(
     Ok(geometry_meshes)
 }
 
-pub enum PreparedMesh {
+pub enum GeometryMesh {
     Point(Vec<Point>),
     LineString { mesh: Mesh },
     Polygon(polygon::PolygonMesh),
 }
 
 trait BuildMesh {
-    fn build(self) -> Option<PreparedMesh>;
+    fn build(self) -> Option<GeometryMesh>;
 }
 
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use geo::algorithm::coords_iter::CoordsIter;
 use std::num::TryFromIntError;
 
 mod line_string;
@@ -174,31 +173,5 @@ impl BuildBevyMeshes for geo::GeometryCollection {
             g.populate_mesh_builders(ctx)?;
         }
         Ok(())
-    }
-}
-
-fn polygon_to_earcutr_input(polygon: &geo::Polygon) -> bevy_earcutr::EarcutrInput {
-    let mut vertices = Vec::with_capacity(polygon.coords_count() * 2);
-    let mut interior_indices = Vec::with_capacity(polygon.interiors().len());
-    debug_assert!(polygon.exterior().0.len() >= 4);
-
-    flat_line_string_coords_2(polygon.exterior(), &mut vertices);
-
-    for interior in polygon.interiors() {
-        debug_assert!(interior.0.len() >= 4);
-        interior_indices.push(vertices.len() / 2);
-        flat_line_string_coords_2(interior, &mut vertices);
-    }
-
-    bevy_earcutr::EarcutrInput {
-        vertices,
-        interior_indices,
-    }
-}
-
-fn flat_line_string_coords_2(line_string: &geo::LineString, vertices: &mut Vec<f64>) {
-    for coord in &line_string.0 {
-        vertices.push(coord.x);
-        vertices.push(coord.y);
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -62,6 +62,6 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
 
 impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
-        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString { mesh })
+        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString(mesh))
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -1,5 +1,4 @@
 use crate::Vertex;
-use bevy::prelude::Color;
 use std::num;
 
 #[derive(Default)]
@@ -29,7 +28,7 @@ impl LineStringMeshBuilder {
         Ok(())
     }
 
-    pub fn build(self, color: Color) -> Option<crate::PreparedMesh> {
+    pub fn build(self) -> Option<crate::PreparedMesh> {
         if self.vertices.is_empty() {
             None
         } else {
@@ -39,7 +38,6 @@ impl LineStringMeshBuilder {
                     self.vertices,
                     self.indices,
                 ),
-                color,
             })
         }
     }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -62,6 +62,6 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
 
 impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
-        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString(mesh))
+        Option::<Mesh>::from(self).map(crate::GeometryMesh::LineString)
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -27,18 +27,24 @@ impl LineStringMeshBuilder {
         }
         Ok(())
     }
+}
 
-    pub fn build(self) -> Option<crate::PreparedMesh> {
+impl From<LineStringMeshBuilder> for bevy::prelude::Mesh {
+    fn from(line_string_builder: LineStringMeshBuilder) -> Self {
+        crate::build_mesh_from_vertices(
+            bevy::render::render_resource::PrimitiveTopology::LineList,
+            line_string_builder.vertices,
+            line_string_builder.indices,
+        )
+    }
+}
+
+impl crate::BuildMesh for LineStringMeshBuilder {
+    fn build(self) -> Option<crate::PreparedMesh> {
         if self.vertices.is_empty() {
             None
         } else {
-            Some(crate::PreparedMesh::LineString {
-                mesh: crate::build_mesh_from_vertices(
-                    bevy::render::render_resource::PrimitiveTopology::LineList,
-                    self.vertices,
-                    self.indices,
-                ),
-            })
+            Some(crate::PreparedMesh::LineString { mesh: self.into() })
         }
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -50,12 +50,18 @@ impl From<LineStringMeshBuilder> for Mesh {
     }
 }
 
-impl crate::BuildMesh for LineStringMeshBuilder {
-    fn build(self) -> Option<crate::PreparedMesh> {
-        if self.vertices.is_empty() {
+impl From<LineStringMeshBuilder> for Option<Mesh> {
+    fn from(line_string_mesh_builder: LineStringMeshBuilder) -> Self {
+        if line_string_mesh_builder.vertices.is_empty() {
             None
         } else {
-            Some(crate::PreparedMesh::LineString { mesh: self.into() })
+            Some(line_string_mesh_builder.into())
         }
+    }
+}
+
+impl crate::BuildMesh for LineStringMeshBuilder {
+    fn build(self) -> Option<crate::PreparedMesh> {
+        Option::<Mesh>::from(self).map(|mesh| crate::PreparedMesh::LineString { mesh })
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -61,7 +61,7 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
 }
 
 impl crate::BuildMesh for LineStringMeshBuilder {
-    fn build(self) -> Option<crate::PreparedMesh> {
-        Option::<Mesh>::from(self).map(|mesh| crate::PreparedMesh::LineString { mesh })
+    fn build(self) -> Option<crate::GeometryMesh> {
+        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString { mesh })
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -1,5 +1,7 @@
-use crate::Vertex;
+use bevy::prelude::Mesh;
 use std::num;
+
+type Vertex = [f32; 3]; // [x, y, z]
 
 #[derive(Default)]
 pub struct LineStringMeshBuilder {
@@ -29,13 +31,22 @@ impl LineStringMeshBuilder {
     }
 }
 
-impl From<LineStringMeshBuilder> for bevy::prelude::Mesh {
+impl From<LineStringMeshBuilder> for Mesh {
     fn from(line_string_builder: LineStringMeshBuilder) -> Self {
-        crate::build_mesh_from_vertices(
-            bevy::render::render_resource::PrimitiveTopology::LineList,
-            line_string_builder.vertices,
-            line_string_builder.indices,
-        )
+        let vertices = line_string_builder.vertices;
+        let indices = line_string_builder.indices;
+        let num_vertices = vertices.len();
+        let mut mesh = Mesh::new(bevy::render::render_resource::PrimitiveTopology::LineList);
+        mesh.set_indices(Some(bevy::render::mesh::Indices::U32(indices)));
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+
+        let normals = vec![[0.0, 0.0, 0.0]; num_vertices];
+        let uvs = vec![[0.0, 0.0]; num_vertices];
+
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+
+        mesh
     }
 }
 

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -60,7 +60,7 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
     }
 }
 
-impl crate::BuildMesh for LineStringMeshBuilder {
+impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
         Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString { mesh })
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -13,7 +13,7 @@ impl PointMeshBuilder {
     }
 }
 
-impl crate::BuildMesh for PointMeshBuilder {
+impl crate::build_mesh::BuildMesh for PointMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
         if self.points.is_empty() {
             None

--- a/src/point.rs
+++ b/src/point.rs
@@ -14,11 +14,11 @@ impl PointMeshBuilder {
 }
 
 impl crate::BuildMesh for PointMeshBuilder {
-    fn build(self) -> Option<crate::PreparedMesh> {
+    fn build(self) -> Option<crate::GeometryMesh> {
         if self.points.is_empty() {
             None
         } else {
-            Some(crate::PreparedMesh::Point(self.points))
+            Some(crate::GeometryMesh::Point(self.points))
         }
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -11,8 +11,10 @@ impl PointMeshBuilder {
         self.points.push(*point);
         Ok(())
     }
+}
 
-    pub fn build(self) -> Option<crate::PreparedMesh> {
+impl crate::BuildMesh for PointMeshBuilder {
+    fn build(self) -> Option<crate::PreparedMesh> {
         if self.points.is_empty() {
             None
         } else {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,0 +1,42 @@
+use crate::{line_string::LineStringMeshBuilder, PreparedMesh};
+
+#[derive(Default)]
+pub struct PolygonMeshBuilder {
+    polygon: bevy_earcutr::PolygonMeshBuilder,
+    exterior: LineStringMeshBuilder,
+    interiors: Vec<LineStringMeshBuilder>,
+}
+
+impl PolygonMeshBuilder {
+    pub fn add_polygon_components(
+        &mut self,
+        polygon: &geo::Polygon,
+    ) -> Result<(), std::num::TryFromIntError> {
+        self.polygon
+            .add_earcutr_input(crate::polygon_to_earcutr_input(polygon));
+        self.exterior.add_line_string(polygon.exterior())?;
+        for interior in polygon.interiors() {
+            let mut interior_line_string_builder = LineStringMeshBuilder::default();
+            interior_line_string_builder.add_line_string(interior)?;
+            self.interiors.push(interior_line_string_builder);
+        }
+
+        Ok(())
+    }
+}
+
+impl crate::BuildMesh for PolygonMeshBuilder {
+    fn build(self) -> Option<PreparedMesh> {
+        self.polygon
+            .build()
+            .map(|polygon_mesh| PreparedMesh::Polygon {
+                polygon_mesh,
+                exterior_mesh: self.exterior.into(),
+                interior_meshes: self
+                    .interiors
+                    .into_iter()
+                    .map(|interior_builder| interior_builder.into())
+                    .collect(),
+            })
+    }
+}

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -4,7 +4,7 @@ use geo::CoordsIter;
 use geo_types::{LineString, Polygon};
 
 pub struct PolygonMesh {
-    pub polygon_mesh: Mesh,
+    pub mesh: Mesh,
     pub exterior_mesh: Mesh,
     pub interior_meshes: Vec<Mesh>,
 }
@@ -63,7 +63,7 @@ impl From<PolygonMeshBuilder> for Option<PolygonMesh> {
             .polygon
             .build()
             .map(|polygon_mesh| PolygonMesh {
-                polygon_mesh,
+                mesh: polygon_mesh,
                 exterior_mesh: polygon_mesh_builder.exterior.into(),
                 interior_meshes: polygon_mesh_builder
                     .interiors

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -74,7 +74,7 @@ impl From<PolygonMeshBuilder> for Option<PolygonMesh> {
     }
 }
 
-impl crate::BuildMesh for PolygonMeshBuilder {
+impl crate::build_mesh::BuildMesh for PolygonMeshBuilder {
     fn build(self) -> Option<GeometryMesh> {
         Option::<PolygonMesh>::from(self).map(GeometryMesh::Polygon)
     }

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,4 +1,4 @@
-use crate::{line_string::LineStringMeshBuilder, PreparedMesh};
+use crate::{line_string::LineStringMeshBuilder, GeometryMesh};
 use bevy::prelude::Mesh;
 use geo::CoordsIter;
 use geo_types::{LineString, Polygon};
@@ -75,7 +75,7 @@ impl From<PolygonMeshBuilder> for Option<PolygonMesh> {
 }
 
 impl crate::BuildMesh for PolygonMeshBuilder {
-    fn build(self) -> Option<PreparedMesh> {
-        Option::<PolygonMesh>::from(self).map(PreparedMesh::Polygon)
+    fn build(self) -> Option<GeometryMesh> {
+        Option::<PolygonMesh>::from(self).map(GeometryMesh::Polygon)
     }
 }


### PR DESCRIPTION
Summary of the biggest changes in this PR:

* Each geometry has a `<geometry>_to_mesh()` method. Return signature depends on the geometry.
* `build_bevy_meshes` and its respective traits are hidden from the public API.
* `PreparedMesh` (now called `GeometryMesh`) is only returned by `geometry_to_mesh` or `geometry_collection_to_mesh`.

Depends on: https://github.com/frewsxcv/geo-bevy/pull/8

Being able to ask `geo-bevy` to prepare a mesh for a given geometry means that one doesn't have to loop over an iterator and match on `PreparedMesh` when the user knows that only one mesh is returned and which variant it is.
This was made possible in #8 due to how line string meshes representing the polygon's exterior and interiors rings are in that PR passed with the `PreparedMesh::Polygon` variant.

