### PR TITLE
Remove `TryFromInt` error handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,3 @@ bevy-earcutr = "0.9"
 bevy = { version = "0.10", default-features = false,  features = ["bevy_render"] }
 geo = "0.25"
 geo-types = "0.7"
-
-[patch.crates-io]
-# TEMP: https://github.com/georust/geo/pull/1020 is yet to included in a release.
-geo-types = { git = "https://github.com/georust/geo" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ license = "MIT OR Apache-2.0"
 bevy-earcutr = "0.9"
 bevy = { version = "0.10", default-features = false,  features = ["bevy_render"] }
 geo = "0.25"
+geo-types = "0.7"
+
+[patch.crates-io]
+# TEMP: https://github.com/georust/geo/pull/1020 is yet to included in a release.
+geo-types = { git = "https://github.com/georust/geo" }

--- a/src/build_mesh.rs
+++ b/src/build_mesh.rs
@@ -1,5 +1,4 @@
 use geo_types::*;
-use std::num::TryFromIntError;
 
 pub trait BuildMesh {
     fn build(self) -> Option<crate::GeometryMesh>;
@@ -13,131 +12,90 @@ pub struct BuildBevyMeshesContext {
 }
 
 pub trait BuildBevyMeshes {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError>;
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext);
 }
 
 impl BuildBevyMeshes for Point {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
-        ctx.point_mesh_builder.add_point(self)
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
+        ctx.point_mesh_builder.add_point(self);
     }
 }
 
 impl BuildBevyMeshes for LineString {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
-        ctx.line_string_mesh_builder.add_line_string(self)
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
+        ctx.line_string_mesh_builder.add_line_string(self);
     }
 }
 
 impl BuildBevyMeshes for Polygon {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
-        ctx.polygon_mesh_builder.add_polygon(self)
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
+        ctx.polygon_mesh_builder.add_polygon(self);
     }
 }
 
 impl BuildBevyMeshes for MultiPoint {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
         for point in &self.0 {
-            point.populate_mesh_builders(ctx)?;
+            point.populate_mesh_builders(ctx);
         }
-        Ok(())
     }
 }
 
 impl BuildBevyMeshes for MultiLineString {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
         for line_string in &self.0 {
-            line_string.populate_mesh_builders(ctx)?;
+            line_string.populate_mesh_builders(ctx);
         }
-        Ok(())
     }
 }
 
 impl BuildBevyMeshes for MultiPolygon {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
         for polygon in &self.0 {
-            polygon.populate_mesh_builders(ctx)?;
+            polygon.populate_mesh_builders(ctx);
         }
-        Ok(())
     }
 }
 
 impl BuildBevyMeshes for Line {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
-        LineString::from(self).populate_mesh_builders(ctx)
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
+        LineString::from(self).populate_mesh_builders(ctx);
     }
 }
 
 impl BuildBevyMeshes for Triangle {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
-        self.to_polygon().populate_mesh_builders(ctx)
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
+        self.to_polygon().populate_mesh_builders(ctx);
     }
 }
 
 impl BuildBevyMeshes for Rect {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
-        self.to_polygon().populate_mesh_builders(ctx)
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
+        self.to_polygon().populate_mesh_builders(ctx);
     }
 }
 
 impl BuildBevyMeshes for Geometry {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
         match self {
-            Geometry::Point(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::Line(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::LineString(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::Polygon(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::MultiPoint(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::MultiLineString(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::MultiPolygon(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::GeometryCollection(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::Triangle(g) => g.populate_mesh_builders(ctx)?,
-            Geometry::Rect(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Point(g) => g.populate_mesh_builders(ctx),
+            Geometry::Line(g) => g.populate_mesh_builders(ctx),
+            Geometry::LineString(g) => g.populate_mesh_builders(ctx),
+            Geometry::Polygon(g) => g.populate_mesh_builders(ctx),
+            Geometry::MultiPoint(g) => g.populate_mesh_builders(ctx),
+            Geometry::MultiLineString(g) => g.populate_mesh_builders(ctx),
+            Geometry::MultiPolygon(g) => g.populate_mesh_builders(ctx),
+            Geometry::GeometryCollection(g) => g.populate_mesh_builders(ctx),
+            Geometry::Triangle(g) => g.populate_mesh_builders(ctx),
+            Geometry::Rect(g) => g.populate_mesh_builders(ctx),
         };
-        Ok(())
     }
 }
 
 impl BuildBevyMeshes for GeometryCollection {
-    fn populate_mesh_builders(
-        &self,
-        ctx: &mut BuildBevyMeshesContext,
-    ) -> Result<(), TryFromIntError> {
+    fn populate_mesh_builders(&self, ctx: &mut BuildBevyMeshesContext) {
         for g in self {
-            g.populate_mesh_builders(ctx)?;
+            g.populate_mesh_builders(ctx);
         }
-        Ok(())
     }
 }

--- a/src/build_mesh.rs
+++ b/src/build_mesh.rs
@@ -1,0 +1,143 @@
+use geo_types::*;
+use std::num::TryFromIntError;
+
+pub trait BuildMesh {
+    fn build(self) -> Option<crate::GeometryMesh>;
+}
+
+#[derive(Default)]
+pub struct BuildBevyMeshesContext {
+    pub point_mesh_builder: crate::point::PointMeshBuilder,
+    pub line_string_mesh_builder: crate::line_string::LineStringMeshBuilder,
+    pub polygon_mesh_builder: crate::polygon::PolygonMeshBuilder,
+}
+
+pub trait BuildBevyMeshes {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError>;
+}
+
+impl BuildBevyMeshes for Point {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        ctx.point_mesh_builder.add_point(self)
+    }
+}
+
+impl BuildBevyMeshes for LineString {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        ctx.line_string_mesh_builder.add_line_string(self)
+    }
+}
+
+impl BuildBevyMeshes for Polygon {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        ctx.polygon_mesh_builder.add_polygon(self)
+    }
+}
+
+impl BuildBevyMeshes for MultiPoint {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for point in &self.0 {
+            point.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for MultiLineString {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for line_string in &self.0 {
+            line_string.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for MultiPolygon {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for polygon in &self.0 {
+            polygon.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for Line {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        LineString::from(self).populate_mesh_builders(ctx)
+    }
+}
+
+impl BuildBevyMeshes for Triangle {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        self.to_polygon().populate_mesh_builders(ctx)
+    }
+}
+
+impl BuildBevyMeshes for Rect {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        self.to_polygon().populate_mesh_builders(ctx)
+    }
+}
+
+impl BuildBevyMeshes for Geometry {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        match self {
+            Geometry::Point(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Line(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::LineString(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Polygon(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::MultiPoint(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::MultiLineString(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::MultiPolygon(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::GeometryCollection(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Triangle(g) => g.populate_mesh_builders(ctx)?,
+            Geometry::Rect(g) => g.populate_mesh_builders(ctx)?,
+        };
+        Ok(())
+    }
+}
+
+impl BuildBevyMeshes for GeometryCollection {
+    fn populate_mesh_builders(
+        &self,
+        ctx: &mut BuildBevyMeshesContext,
+    ) -> Result<(), TryFromIntError> {
+        for g in self {
+            g.populate_mesh_builders(ctx)?;
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,6 @@ pub fn geometry_collection_to_mesh(
 
 pub enum GeometryMesh {
     Point(Vec<Point>),
-    LineString { mesh: Mesh },
+    LineString(Mesh),
     Polygon(polygon::PolygonMesh),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ use build_mesh::{BuildBevyMeshes, BuildMesh};
 use geo_types::geometry::*;
 use line_string::LineStringMeshBuilder;
 use polygon::PolygonMeshBuilder;
-use std::num::TryFromIntError;
 
 pub use polygon::PolygonMesh;
 
@@ -12,88 +11,82 @@ mod line_string;
 mod point;
 mod polygon;
 
-pub fn line_to_mesh(line: &Line) -> Result<Option<Mesh>, TryFromIntError> {
+pub fn line_to_mesh(line: &Line) -> Option<Mesh> {
     line_string_to_mesh(&line.into())
 }
 
-pub fn line_string_to_mesh(line_string: &LineString) -> Result<Option<Mesh>, TryFromIntError> {
+pub fn line_string_to_mesh(line_string: &LineString) -> Option<Mesh> {
     let mut mesh_builder = LineStringMeshBuilder::default();
-    mesh_builder.add_line_string(line_string)?;
-    Ok(mesh_builder.into())
+    mesh_builder.add_line_string(line_string);
+    mesh_builder.into()
 }
 
-pub fn multi_line_string_to_mesh(
-    multi_line_string: &MultiLineString,
-) -> Result<Vec<Mesh>, TryFromIntError> {
+pub fn multi_line_string_to_mesh(multi_line_string: &MultiLineString) -> Vec<Mesh> {
     let line_strings = &multi_line_string.0;
     let mut line_string_meshes = Vec::with_capacity(line_strings.len());
 
     for line_string in line_strings {
-        if let Some(line_string_mesh) = line_string_to_mesh(line_string)? {
+        if let Some(line_string_mesh) = line_string_to_mesh(line_string) {
             line_string_meshes.push(line_string_mesh);
         }
     }
 
-    Ok(line_string_meshes)
+    line_string_meshes
 }
 
-pub fn polygon_to_mesh(polygon: &Polygon) -> Result<Option<PolygonMesh>, TryFromIntError> {
+pub fn polygon_to_mesh(polygon: &Polygon) -> Option<PolygonMesh> {
     let mut mesh_builder = PolygonMeshBuilder::default();
-    mesh_builder.add_polygon(polygon)?;
-    Ok(mesh_builder.into())
+    mesh_builder.add_polygon(polygon);
+    mesh_builder.into()
 }
 
-pub fn multi_polygon_to_mesh(
-    multi_polygon: &MultiPolygon,
-) -> Result<Vec<PolygonMesh>, TryFromIntError> {
+pub fn multi_polygon_to_mesh(multi_polygon: &MultiPolygon) -> Vec<PolygonMesh> {
     let polygons = &multi_polygon.0;
     let mut polygon_meshes = Vec::with_capacity(polygons.len());
     for polygon in polygons {
-        if let Some(polygon_mesh) = polygon_to_mesh(polygon)? {
+        if let Some(polygon_mesh) = polygon_to_mesh(polygon) {
             polygon_meshes.push(polygon_mesh);
         }
     }
 
-    Ok(polygon_meshes)
+    polygon_meshes
 }
 
-pub fn rect_to_mesh(rect: &Rect) -> Result<Option<PolygonMesh>, TryFromIntError> {
+pub fn rect_to_mesh(rect: &Rect) -> Option<PolygonMesh> {
     polygon_to_mesh(&rect.to_polygon())
 }
 
-pub fn triangle_to_mesh(triangle: &Triangle) -> Result<Option<PolygonMesh>, TryFromIntError> {
+pub fn triangle_to_mesh(triangle: &Triangle) -> Option<PolygonMesh> {
     polygon_to_mesh(&triangle.to_polygon())
 }
 
-pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<GeometryMesh>, TryFromIntError> {
+pub fn geometry_to_mesh(geometry: &Geometry) -> Option<GeometryMesh> {
     let mut ctx = build_mesh::BuildBevyMeshesContext::default();
 
     info_span!("Populating Bevy mesh builder")
-        .in_scope(|| geometry.populate_mesh_builders(&mut ctx))?;
+        .in_scope(|| geometry.populate_mesh_builders(&mut ctx));
 
     info_span!("Building Bevy meshes").in_scope(|| {
-        Ok([
+        [
             ctx.point_mesh_builder.build(),
             ctx.line_string_mesh_builder.build(),
             ctx.polygon_mesh_builder.build(),
         ]
         .into_iter()
         .find(|prepared_mesh| prepared_mesh.is_some())
-        .unwrap_or_default())
+        .unwrap_or_default()
     })
 }
 
-pub fn geometry_collection_to_mesh(
-    geometry_collection: &GeometryCollection,
-) -> Result<Vec<GeometryMesh>, TryFromIntError> {
+pub fn geometry_collection_to_mesh(geometry_collection: &GeometryCollection) -> Vec<GeometryMesh> {
     let mut geometry_meshes = Vec::with_capacity(geometry_collection.len());
     for geometry in geometry_collection {
-        if let Some(geometry_mesh) = geometry_to_mesh(geometry)? {
+        if let Some(geometry_mesh) = geometry_to_mesh(geometry) {
             geometry_meshes.push(geometry_mesh);
         }
     }
 
-    Ok(geometry_meshes)
+    geometry_meshes
 }
 
 pub enum GeometryMesh {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 use bevy::prelude::{info_span, Mesh};
-use build_mesh::BuildBevyMeshes;
-use build_mesh::BuildMesh;
+use build_mesh::{BuildBevyMeshes, BuildMesh};
 use geo_types::geometry::*;
 use line_string::LineStringMeshBuilder;
-use polygon::PolygonMesh;
 use polygon::PolygonMeshBuilder;
 use std::num::TryFromIntError;
+
+pub use polygon::PolygonMesh;
 
 mod build_mesh;
 mod line_string;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn triangle_to_mesh(triangle: &Triangle) -> Result<Option<PolygonMesh>, TryF
     polygon_to_mesh(&triangle.to_polygon())
 }
 
-pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<PreparedMesh>, TryFromIntError> {
+pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<GeometryMesh>, TryFromIntError> {
     let mut ctx = BuildBevyMeshesContext::default();
 
     info_span!("Populating Bevy mesh builder")
@@ -82,7 +82,7 @@ pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Option<PreparedMesh>, Try
 
 pub fn geometry_collection_to_mesh(
     geometry_collection: &GeometryCollection,
-) -> Result<Vec<PreparedMesh>, TryFromIntError> {
+) -> Result<Vec<GeometryMesh>, TryFromIntError> {
     let mut geometry_meshes = Vec::with_capacity(geometry_collection.len());
     for geometry in geometry_collection {
         if let Some(geometry_mesh) = geometry_to_mesh(geometry)? {
@@ -93,14 +93,14 @@ pub fn geometry_collection_to_mesh(
     Ok(geometry_meshes)
 }
 
-pub enum PreparedMesh {
+pub enum GeometryMesh {
     Point(Vec<Point>),
     LineString { mesh: Mesh },
     Polygon(polygon::PolygonMesh),
 }
 
 trait BuildMesh {
-    fn build(self) -> Option<PreparedMesh>;
+    fn build(self) -> Option<GeometryMesh>;
 }
 
 #[derive(Default)]

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -62,6 +62,6 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
 
 impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
-        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString { mesh })
+        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString(mesh))
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::Mesh;
-use std::num;
 
 type Vertex = [f32; 3]; // [x, y, z]
 
@@ -11,10 +10,7 @@ pub struct LineStringMeshBuilder {
 
 impl LineStringMeshBuilder {
     /// Call for `add_earcutr_input` for each polygon you want to add to the mesh.
-    pub fn add_line_string(
-        &mut self,
-        line_string: &geo::LineString,
-    ) -> Result<(), num::TryFromIntError> {
+    pub fn add_line_string(&mut self, line_string: &geo::LineString) {
         let index_base = self.vertices.len();
 
         self.vertices.reserve(self.vertices.len());
@@ -23,11 +19,10 @@ impl LineStringMeshBuilder {
         for (i, coord) in line_string.0.iter().enumerate() {
             self.vertices.push([coord.x as f32, coord.y as f32, 0.0f32]);
             if i != line_string.0.len() - 1 {
-                self.indices.push(u32::try_from(index_base + i)?);
-                self.indices.push(u32::try_from(index_base + i + 1)?);
+                self.indices.push((index_base + i) as u32);
+                self.indices.push((index_base + i + 1) as u32);
             }
         }
-        Ok(())
     }
 }
 

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::Mesh;
+use bevy::prelude::{error, Mesh};
 
 type Vertex = [f32; 3]; // [x, y, z]
 
@@ -10,14 +10,24 @@ pub struct LineStringMeshBuilder {
 
 impl LineStringMeshBuilder {
     /// Call for `add_earcutr_input` for each polygon you want to add to the mesh.
-    /// Panics if self.vertices.len() + linestring coords > u32::MAX (4_294_967_295).
+    /// Logs error if self.vertices.len() + linestring coords > u32::MAX (4_294_967_295).
     pub fn add_line_string(&mut self, line_string: &geo::LineString) {
         let index_base = self.vertices.len();
+        let line_string_vec = &line_string.0;
+
+        let max_index = index_base + line_string_vec.len();
+        if max_index > u32::MAX as usize {
+            error!(
+                "Integer overflow in LineStringMeshBuilder.add_line_string(): {}",
+                max_index
+            );
+            return;
+        }
 
         self.vertices.reserve(self.vertices.len());
         self.indices.reserve(self.indices.len() * 2);
 
-        for (i, coord) in line_string.0.iter().enumerate() {
+        for (i, coord) in line_string_vec.iter().enumerate() {
             self.vertices.push([coord.x as f32, coord.y as f32, 0.0f32]);
             if i != line_string.0.len() - 1 {
                 self.indices.push((index_base + i) as u32);

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -62,6 +62,6 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
 
 impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
-        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString(mesh))
+        Option::<Mesh>::from(self).map(crate::GeometryMesh::LineString)
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -10,6 +10,7 @@ pub struct LineStringMeshBuilder {
 
 impl LineStringMeshBuilder {
     /// Call for `add_earcutr_input` for each polygon you want to add to the mesh.
+    /// Panics if self.vertices.len() + linestring coords > u32::MAX (4_294_967_295).
     pub fn add_line_string(&mut self, line_string: &geo::LineString) {
         let index_base = self.vertices.len();
 

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -50,12 +50,18 @@ impl From<LineStringMeshBuilder> for Mesh {
     }
 }
 
-impl crate::BuildMesh for LineStringMeshBuilder {
-    fn build(self) -> Option<crate::PreparedMesh> {
-        if self.vertices.is_empty() {
+impl From<LineStringMeshBuilder> for Option<Mesh> {
+    fn from(line_string_mesh_builder: LineStringMeshBuilder) -> Self {
+        if line_string_mesh_builder.vertices.is_empty() {
             None
         } else {
-            Some(crate::PreparedMesh::LineString { mesh: self.into() })
+            Some(line_string_mesh_builder.into())
         }
+    }
+}
+
+impl crate::BuildMesh for LineStringMeshBuilder {
+    fn build(self) -> Option<crate::PreparedMesh> {
+        Option::<Mesh>::from(self).map(|mesh| crate::PreparedMesh::LineString { mesh })
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -61,7 +61,7 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
 }
 
 impl crate::BuildMesh for LineStringMeshBuilder {
-    fn build(self) -> Option<crate::PreparedMesh> {
-        Option::<Mesh>::from(self).map(|mesh| crate::PreparedMesh::LineString { mesh })
+    fn build(self) -> Option<crate::GeometryMesh> {
+        Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString { mesh })
     }
 }

--- a/src/line_string.rs
+++ b/src/line_string.rs
@@ -60,7 +60,7 @@ impl From<LineStringMeshBuilder> for Option<Mesh> {
     }
 }
 
-impl crate::BuildMesh for LineStringMeshBuilder {
+impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
         Option::<Mesh>::from(self).map(|mesh| crate::GeometryMesh::LineString { mesh })
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -13,7 +13,7 @@ impl PointMeshBuilder {
     }
 }
 
-impl crate::BuildMesh for PointMeshBuilder {
+impl crate::build_mesh::BuildMesh for PointMeshBuilder {
     fn build(self) -> Option<crate::GeometryMesh> {
         if self.points.is_empty() {
             None

--- a/src/point.rs
+++ b/src/point.rs
@@ -14,11 +14,11 @@ impl PointMeshBuilder {
 }
 
 impl crate::BuildMesh for PointMeshBuilder {
-    fn build(self) -> Option<crate::PreparedMesh> {
+    fn build(self) -> Option<crate::GeometryMesh> {
         if self.points.is_empty() {
             None
         } else {
-            Some(crate::PreparedMesh::Point(self.points))
+            Some(crate::GeometryMesh::Point(self.points))
         }
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,5 +1,3 @@
-use std::num;
-
 #[derive(Default)]
 pub struct PointMeshBuilder {
     points: Vec<geo::Point>,
@@ -7,9 +5,8 @@ pub struct PointMeshBuilder {
 
 impl PointMeshBuilder {
     /// Call for `add_earcutr_input` for each polygon you want to add to the mesh.
-    pub fn add_point(&mut self, point: &geo::Point) -> Result<(), num::TryFromIntError> {
+    pub fn add_point(&mut self, point: &geo::Point) {
         self.points.push(*point);
-        Ok(())
     }
 }
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -4,7 +4,7 @@ use geo::CoordsIter;
 use geo_types::{LineString, Polygon};
 
 pub struct PolygonMesh {
-    pub polygon_mesh: Mesh,
+    pub mesh: Mesh,
     pub exterior_mesh: Mesh,
     pub interior_meshes: Vec<Mesh>,
 }
@@ -63,7 +63,7 @@ impl From<PolygonMeshBuilder> for Option<PolygonMesh> {
             .polygon
             .build()
             .map(|polygon_mesh| PolygonMesh {
-                polygon_mesh,
+                mesh: polygon_mesh,
                 exterior_mesh: polygon_mesh_builder.exterior.into(),
                 interior_meshes: polygon_mesh_builder
                     .interiors

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -74,7 +74,7 @@ impl From<PolygonMeshBuilder> for Option<PolygonMesh> {
     }
 }
 
-impl crate::BuildMesh for PolygonMeshBuilder {
+impl crate::build_mesh::BuildMesh for PolygonMeshBuilder {
     fn build(self) -> Option<GeometryMesh> {
         Option::<PolygonMesh>::from(self).map(GeometryMesh::Polygon)
     }

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -17,17 +17,15 @@ pub struct PolygonMeshBuilder {
 }
 
 impl PolygonMeshBuilder {
-    pub fn add_polygon(&mut self, polygon: &Polygon) -> Result<(), std::num::TryFromIntError> {
+    pub fn add_polygon(&mut self, polygon: &Polygon) {
         self.polygon
             .add_earcutr_input(Self::polygon_to_earcutr_input(polygon));
-        self.exterior.add_line_string(polygon.exterior())?;
+        self.exterior.add_line_string(polygon.exterior());
         for interior in polygon.interiors() {
             let mut interior_line_string_builder = LineStringMeshBuilder::default();
-            interior_line_string_builder.add_line_string(interior)?;
+            interior_line_string_builder.add_line_string(interior);
             self.interiors.push(interior_line_string_builder);
         }
-
-        Ok(())
     }
 
     fn polygon_to_earcutr_input(polygon: &Polygon) -> bevy_earcutr::EarcutrInput {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,4 +1,4 @@
-use crate::{line_string::LineStringMeshBuilder, PreparedMesh};
+use crate::{line_string::LineStringMeshBuilder, GeometryMesh};
 use bevy::prelude::Mesh;
 use geo::CoordsIter;
 use geo_types::{LineString, Polygon};
@@ -75,7 +75,7 @@ impl From<PolygonMeshBuilder> for Option<PolygonMesh> {
 }
 
 impl crate::BuildMesh for PolygonMeshBuilder {
-    fn build(self) -> Option<PreparedMesh> {
-        Option::<PolygonMesh>::from(self).map(PreparedMesh::Polygon)
+    fn build(self) -> Option<GeometryMesh> {
+        Option::<PolygonMesh>::from(self).map(GeometryMesh::Polygon)
     }
 }


### PR DESCRIPTION
Core change is:

```diff
-                self.indices.push(u32::try_from(index_base + i)?);
-                self.indices.push(u32::try_from(index_base + i + 1)?);
+                self.indices.push((index_base + i) as u32);
+                self.indices.push((index_base + i + 1) as u32);
```

Panic is avoided by asserting that:

```rust
    let max_index = index_base + line_string_vec.len();
    if max_index > u32::MAX as usize {
        error!(
            "Integer overflow in LineStringMeshBuilder.add_line_string(): {}",
            max_index
        );
        return;
    }
```

I would argue that this integer overflow is so rare that it is better to just report an error and return, rather than requiring the user to deal with this case on every library interaction.

Depends on: #9 